### PR TITLE
Replace 'javascript' in descriptions with 'JavaScript'

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "moment",
   "version": "2.8.4",
   "main": "moment.js",
-  "description": "Parse, validate, manipulate, and display dates in javascript.",
+  "description": "Parse, validate, manipulate, and display dates in JavaScript.",
   "files": [
     "moment.js",
     "locale/af.js",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "moment/moment",
-    "description": "Parse, validate, manipulate, and display dates in javascript.",
+    "description": "Parse, validate, manipulate, and display dates in JavaScript.",
     "keywords": [
         "moment",
         "date",


### PR DESCRIPTION
Replace 'javascript' in descriptions with 'JavaScript'.
